### PR TITLE
1.9 compatibility

### DIFF
--- a/db.php
+++ b/db.php
@@ -1,10 +1,17 @@
 <?php
 /*
 SQLite driver for YOURLS.
-Version: 1.2
-This driver requires YOURLS 1.7.4 -- not before -- not after!
+Version: 1.3
+This driver requires YOURLS 1.9.2 - may work with later versions, too.
 Author: Ozh
 */
+
+class CustomYDB extends \YOURLS\Database\YDB {
+  public function escape($string) {
+    // Dirty escape
+    return addslashes($string);
+  }
+}
 
 yourls_db_sqlite_connect();
 
@@ -39,7 +46,7 @@ function yourls_db_sqlite_connect() {
      */
     $attributes     = yourls_apply_filter( 'db_connect_attributes',    array() ); // attributes as key-value pairs
 
-    $ydb = new \YOURLS\Database\YDB( $dsn, "", "", array(), $attributes );
+    $ydb = new CustomYDB( $dsn, "", "", array(), $attributes );
     $ydb->init();
 
     // Past this point, we're connected
@@ -141,7 +148,7 @@ function yourls_sqlite_last_24h_hits() {
 	FROM `yourls_log`
 	WHERE `shorturl` $keyword_range AND `click_time` > datetime('now', '-1 day')
 	GROUP BY `time`;";
-	$rows = $ydb->get_results( $query );
+	$rows = $ydb->fetchObjects( $query );
     
     $_last_24h = array();
 	foreach( (array)$rows as $row ) {

--- a/db.php
+++ b/db.php
@@ -8,8 +8,9 @@ Author: Ozh
 
 class CustomYDB extends \YOURLS\Database\YDB {
   public function escape($string) {
-    // Dirty escape
-    return addslashes($string);
+    // Copied escape function from base YDB
+    // https://github.com/YOURLS/YOURLS/blob/23d21fd996e771c4015f5d8b4ec1b06af122d60b/includes/Database/YDB.php#L429
+    return substr($this->quote($string), 1, -1);
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# An unofficial SQLite Driver for YOURLS 1.8.2
+# An unofficial SQLite Driver for YOURLS 1.9.2
 
 This is a fork of a [fork](https://github.com/reanimus/yourls-sqlite) of the [original](https://github.com/ozh/yourls-sqlite), but now outdated SQLite driver for [YOURLS](https://yourls.org/). To my knowledge, it's the only actively maintained version, now with a readily available Docker image (thanks [@Niduroki](https://github.com/Niduroki)).
 


### PR DESCRIPTION
Upstream has changed to using PDO escape, which we don't use, thus I have implemented a "dirty" addslashes escape within a custom class, which should work fine 🤞

Feel free to do some own testing.

Also I have updated `get_results` to `fetchObjects`. There does not seem to be any difference in functionality, just that `get_results` has been renamed.